### PR TITLE
VTCCA-3368: fix contract for billingAuthCode

### DIFF
--- a/app/models/Assessment.scala
+++ b/app/models/Assessment.scala
@@ -33,6 +33,7 @@ case class Assessment(
       rateableValue: Option[Long],
       address: PropertyAddress,
       billingAuthorityReference: String,
+      billingAuthorityCode: Option[String],
       listType: ListType,
       currentFromDate: Option[LocalDate],
       currentToDate: Option[LocalDate]
@@ -51,18 +52,17 @@ case class Assessments(
 object Assessment {
   implicit val formats = Json.format[Assessment]
 
-  def fromValuationHistory(valuationHistory: ValuationHistory, authorisationId: Long) =
+  def fromValuationHistory(valuationHistory: ValuationHistory, authorisationId: Long): Assessment =
     Assessment(
       authorisationId = authorisationId,
       assessmentRef = valuationHistory.asstRef,
       listYear = valuationHistory.listYear,
       uarn = valuationHistory.uarn,
       effectiveDate = valuationHistory.effectiveDate,
-      rateableValue = valuationHistory.rateableValue.map { d =>
-        d.longValue()
-      },
+      rateableValue = valuationHistory.rateableValue.map(_.longValue()),
       address = PropertyAddress.fromString(valuationHistory.address),
       billingAuthorityReference = valuationHistory.billingAuthorityReference,
+      billingAuthorityCode = valuationHistory.billingAuthCode,
       listType = valuationHistory.listType,
       currentFromDate = valuationHistory.currentFromDate,
       currentToDate = valuationHistory.currentToDate

--- a/app/models/modernised/AllowedAction.scala
+++ b/app/models/modernised/AllowedAction.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.modernised
+
+import play.api.libs.json.Format
+import uk.gov.hmrc.voapropertylinking.utils.JsonUtils.enumFormat
+
+object AllowedAction extends Enumeration {
+
+  type AllowedAction = Value
+
+  val PROPERTY_LINK: AllowedAction = Value("propertyLink")
+  val CHECK: AllowedAction = Value("check")
+  val CHALLENGE: AllowedAction = Value("challenge")
+  val ENQUIRY: AllowedAction = Value("enquiry")
+  val VIEW_DETAILED_VALUATION: AllowedAction = Value("viewDetailedValuation")
+  val BUSINESS_RATES_ESTIMATOR: AllowedAction = Value("businessRatesEstimator")
+  val SIMILAR_PROPERTIES: AllowedAction = Value("similarProperties")
+  val VIEW_APPEALS: AllowedAction = Value("viewAppeals")
+  val PROPOSAL: AllowedAction = Value("proposal")
+
+  implicit val format: Format[AllowedAction] = enumFormat(AllowedAction)
+
+}

--- a/app/models/modernised/ValuationHistory.scala
+++ b/app/models/modernised/ValuationHistory.scala
@@ -16,10 +16,10 @@
 
 package models.modernised
 
-import java.time.LocalDate
-
 import models.modernised.ListType.ListType
 import play.api.libs.json.{Json, OFormat}
+
+import java.time.LocalDate
 
 case class ValuationHistory(
       asstRef: Long,
@@ -40,7 +40,7 @@ case class ValuationHistory(
       transitionalCertificate: Option[Boolean],
       deletedIndicator: Option[Boolean],
       valuationDetailsAvailable: Option[Boolean],
-      billingAuthorityCode: Option[String],
+      billingAuthCode: Option[String],
       currentFromDate: Option[LocalDate] = None,
       currentToDate: Option[LocalDate] = None,
       listType: ListType)

--- a/test/uk/gov/hmrc/voapropertylinking/services/AssessmentServiceSpec.scala
+++ b/test/uk/gov/hmrc/voapropertylinking/services/AssessmentServiceSpec.scala
@@ -95,7 +95,7 @@ class AssessmentServiceSpec extends BaseUnitSpec {
       transitionalCertificate = None,
       deletedIndicator = None,
       valuationDetailsAvailable = None,
-      billingAuthorityCode = None,
+      billingAuthCode = None,
       listType = ListType.CURRENT
     )
 

--- a/test/uk/gov/hmrc/voapropertylinking/services/PropertyLinkingServiceSpec.scala
+++ b/test/uk/gov/hmrc/voapropertylinking/services/PropertyLinkingServiceSpec.scala
@@ -189,7 +189,7 @@ class PropertyLinkingServiceSpec extends BaseUnitSpec {
         transitionalCertificate = None,
         deletedIndicator = None,
         valuationDetailsAvailable = None,
-        billingAuthorityCode = None,
+        billingAuthCode = None,
         listType = ListType.CURRENT
       )))
 


### PR DESCRIPTION
billing authority code wasn't exposed from VPL to VPLF so no one noticed the contract is broken. We're now exposing this to VPLF so I had to update the field name to what it actually is on the modernised API. 